### PR TITLE
fixed issue of being taken to incorrect user page

### DIFF
--- a/entities/User.php
+++ b/entities/User.php
@@ -230,7 +230,7 @@ class User{
 
 	public function update(){
 		$stmt=$this->readOne($this->id);
-		if($stmt->rowCount()==1){
+		if($stmt->rowCount()>0){
 			$sql = "UPDATE users SET display_name=:display_name, email=:email,phone=:phone,updated_by=:updated_by WHERE id=:id";
 			$stmt= $this->connection->prepare($sql);
 			if( $stmt->execute(['id'=>$this->id,'display_name'=>$this->display_name,'email'=>$this->email,'phone'=>$this->phone

--- a/ui/src/js/appController.js
+++ b/ui/src/js/appController.js
@@ -166,7 +166,8 @@ define(['knockout', 'ojs/ojmodule-element-utils', 'ojs/ojresponsiveutils', 'ojs/
       		'offer/{offerId}': {label: 'Offer'},
 			'clients': {label: 'Clients'},
 			'client/{clientId}': {label: 'Client'},
-            'user/{userId}': {label: 'User'},
+            'user/{userId}/{orgId}/{pageFrom}': {label: 'User'},
+            'user/{userId}/{pageFrom}': {label: 'User'},
 			'orgAdmin': {label: 'Org Admin'},
 			'admin': {label: 'Admin'},
 			'preferences': {label: 'Preferences'}

--- a/ui/src/js/viewModels/orgAdmin.js
+++ b/ui/src/js/viewModels/orgAdmin.js
@@ -121,8 +121,7 @@ define(['appController', 'ojs/ojrouter', 'utils', 'ojs/ojcore', 'knockout', 'jqu
                                 }
                             };
                             self.userSelected(searchNodes(event.target.currentRow.rowKey, self.userOrgValues()));
-                            router.go('user/' + self.userSelected().user_id);
-
+                            router.go('user/' + self.userSelected().user_id + '/' + self.userOrgId() + '/' + 'orgAdmin');
                         }
                     };
                 }();

--- a/ui/src/js/viewModels/systemAdminOrganizations.js
+++ b/ui/src/js/viewModels/systemAdminOrganizations.js
@@ -132,7 +132,7 @@ define(['appController', 'utils', 'ojs/ojrouter', 'ojs/ojcore', 'knockout', 'jqu
                             return $.when(restClient.doGetJson('/rest/user_organizations/' + event.detail.value[0].startKey.row)
                                 .then(
                                     success = function (response) {
-                                        router.go('user/' + response.user_id);
+                                        router.go('user/' + response.user_id + "/" + self.orgDetailid() + '/' + 'admin');
                                     },
                                     error = function (response) {
                                         console.log("User organizations not loaded");


### PR DESCRIPTION
closes #141 
When you clicked on a user, it often took you to an incorrect page since it would take you to information about that user from a different org. We have now fixed this so it works as intended.
We also made it when exiting the user page it takes you back to the page you came from.